### PR TITLE
chore(dependabot): disable version updates for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0


### PR DESCRIPTION
I found this configuration that will hopefully prevent dependabot from creating pull-requests while still giving us security warnings. 
https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates